### PR TITLE
Enable cache on CI builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,5 +13,34 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+      - id: cache-key
+        run: echo "week=$(TZ=Asia/Tokyo date +%W)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.gradle/wrapper
+          key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/transforms-*
+            ~/.gradle/caches/modules-*
+          key: gradle-dependencies-${{ steps.cache-key.outputs.week }}-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'build-logic/**/*.{kt,kts}') }}
+          restore-keys: gradle-dependencies-${{ steps.cache-key.outputs.week }}-
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.konan
+            ~/.gradle/native
+          key: ${{ runner.os }}-kotlin-native-${{ steps.cache-key.outputs.week }}-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts') }}
+          restore-keys: ${{ runner.os }}-kotlin-native-${{ steps.cache-key.outputs.week }}-
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches/build-cache-*
+            ~/.gradle/caches/[0-9]*.*
+            .gradle
+          key: ${{ runner.os }}-gradle-build-${{ github.workflow }}-${{ steps.cache-key.outputs.week }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-gradle-build-${{ github.workflow }}-${{ steps.cache-key.outputs.week }}-
       - name: Build
         run: ./gradlew publishToMavenLocal build


### PR DESCRIPTION
CI builds takes about 9 minutes.
This can be pain when we are working on a long-term feature development.

Every time CI build starts, all the dependencies are fetched and it slow down CI cycle.

When cache doesn't exist, CI build took 12 minutes or so. However, the second run without any source changes completed just in about 3.3 minutes.

This is a huge improvement to deliver features faster.